### PR TITLE
Replace commonjs 'module.exports' w/ es6 'export default'

### DIFF
--- a/src/MetroListView.js
+++ b/src/MetroListView.js
@@ -59,7 +59,7 @@ type Props = NormalProps & DefaultProps;
  * some section support tacked on. It is recommended to just use FlatList directly, this component
  * is mostly for debugging and performance comparison.
  */
-class MetroListView extends React.Component<Props, $FlowFixMeState> {
+export default class MetroListView extends React.Component<Props, $FlowFixMeState> {
   scrollToEnd(params?: ?{ animated?: ?boolean }) {
     throw new Error('scrollToEnd not supported in legacy ListView.');
   }
@@ -213,5 +213,3 @@ class MetroListView extends React.Component<Props, $FlowFixMeState> {
     <this.props.SeparatorComponent key={sID + rID} />
   );
 }
-
-module.exports = MetroListView;


### PR DESCRIPTION
Mixing es6 `import` with commonjs `module.exports` results in the following compilation error:

```
./node_modules/react-native-web-lists/src/FlatList.js
26:33-46 "export 'default' (imported as 'MetroListView') was not found in './MetroListView'
```