### PR TITLE
Make the library compatible with iOS and Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,13 @@ This package uses the legacy implementation (ListView).
 ## Getting started
 `$ npm install react-native-web-lists --save`
 
-Alias the package in your webpack config:
-
-```
-resolve: {
-    alias: {
-        'react-native': 'react-native-web',
-        ...
-        'WebLists': 'react-native-web-lists',
-    }
-}
-```
 
 ## Usage
+Note: This implementation will work on Android and iOS because in `index.native.js` the default classes are exported from `react-native`
+
 ```js
-import { FlatList } from 'WebLists'; // don't import from react-native
-import { SectionList } from 'WebLists'; // don't import from react-native
+import { FlatList } from 'react-native-web-lists'; // don't import from react-native
+import { SectionList } from 'react-native-web-lists'; // don't import from react-native
 ```
 
 See [RN's docs](https://facebook.github.io/react-native/docs/flatlist.html).

--- a/README.md
+++ b/README.md
@@ -13,16 +13,15 @@ resolve: {
     alias: {
         'react-native': 'react-native-web',
         ...
-        'FlatList': 'react-native-web-lists/src/FlatList',
-        'SectionList': 'react-native-web-lists/src/SectionList',
+        'WebLists': 'react-native-web-lists',
     }
 }
 ```
 
 ## Usage
 ```js
-import FlatList from 'FlatList'; // don't import from react-native
-import SectionList from 'SectionList'; // don't import from react-native
+import { FlatList } from 'WebLists'; // don't import from react-native
+import { SectionList } from 'WebLists'; // don't import from react-native
 ```
 
 See [RN's docs](https://facebook.github.io/react-native/docs/flatlist.html).

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.1",
   "description": "React Native for Web implementation of Lists",
   "main": "src/index.js",
+  "react-native": "src/index.native.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:react-native-web-community/react-native-web-lists.git"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import FlatList from './FlatList';
 import SectionList from './SectionList';
 
-export default { FlatList, SectionList };
+export FlatList;
+export SectionList;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import FlatList from './FlatList';
 import SectionList from './SectionList';
 
-export FlatList;
-export SectionList;
+export {FlatList, SectionList};

--- a/src/index.native.js
+++ b/src/index.native.js
@@ -1,0 +1,1 @@
+export { FlatList, SectionList } from "react-native";


### PR DESCRIPTION
In order to make the library compatible with iOS and Android I've included an `index.native.js` to export the `FlatList` and `SectionList` classes from `react-native` in case we are not running in a web environment (this is detected in `package.json`).
The drawback is that we no longer can import from aliases, instead, we import directly from `react-native-web-lists`. If this isn't a problem I offer a PR to merge with master.

Thanks in advance.